### PR TITLE
GH-3 - Build now against 4.0.0-beta03 by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,8 @@
 		<maven-source-plugin.version>3.0.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
 		<neo4j-java-driver.version>4.0.0-rc1</neo4j-java-driver.version>
-		<neo4j.version>3.5.12</neo4j.version>
+		<neo4j.repository>neo4j/neo4j-experimental</neo4j.repository>
+		<neo4j.version>4.0.0-beta03mr03</neo4j.version>
 		<revision>4.0</revision>
 		<sha1></sha1>
 		<sortpom-maven-plugin.version>2.8.0</sortpom-maven-plugin.version>
@@ -226,12 +227,28 @@
 							<rules>
 								<DependencyConvergence></DependencyConvergence>
 								<requireMavenVersion>
-									<version>3.6.0</version>
+									<version>3.6.1</version>
 								</requireMavenVersion>
 							</rules>
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemProperties>
+						<property>
+							<name>SPRING_BOOT_STARTER_NEO4J_REPOSITORY</name>
+							<value>${neo4j.repository}</value>
+						</property>
+						<property>
+							<name>SPRING_BOOT_STARTER_NEO4J_VERSION</name>
+							<value>${neo4j.version}</value>
+						</property>
+					</systemProperties>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -244,6 +261,18 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<systemProperties>
+						<property>
+							<name>SPRING_BOOT_STARTER_NEO4J_REPOSITORY</name>
+							<value>${neo4j.repository}</value>
+						</property>
+						<property>
+							<name>SPRING_BOOT_STARTER_NEO4J_VERSION</name>
+							<value>${neo4j.version}</value>
+						</property>
+					</systemProperties>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The docker image against which the integration tests run can now be select via system or environmental properties `SPRING_BOOT_STARTER_NEO4J_REPOSITORY` and `SPRING_BOOT_STARTER_NEO4J_VERSION`, where the environmental properties have precende over the system properties. The system properties defaults to `neo4j/neo4j-experimental:4.0.0-beta03mr03` via maven. If none set, we fallback to `neo4j:3.5.13` (for example when run via IDE).