### PR TITLE
Clarify defaults and requirements of org.neo4j.driver.uri property.

### DIFF
--- a/docs/appendix/configuration-options.adoc
+++ b/docs/appendix/configuration-options.adoc
@@ -70,7 +70,7 @@
 
 |`{config_prefix}.uri`
 |
-|+++The uri this driver should connect to. The driver supports bolt, bolt+routing or neo4j as schemes. The default URI is 'bolt://localhost:7687'.+++
+|+++The uri this driver should connect to. The driver supports bolt or neo4j as schemes. The starter does not provide a default URI so that clashes with the SDN/OGM Spring Boot starter are avoided.+++
 
 |`{config_prefix}.pool.metrics-enabled`
 |`false`

--- a/docs/manual/getting-started.adoc
+++ b/docs/manual/getting-started.adoc
@@ -121,6 +121,12 @@ org.neo4j.driver.authentication.username=neo4j
 org.neo4j.driver.authentication.password=secret
 ----
 
+IMPORTANT: The URI is required. Autoconfiguration will not be triggered without it.
+           This is to avoid clashes with the Spring Boot SDN/OGM starter.
+           The SDN/OGM starter defaults to localhost, but backs off when it detects a driver bean.
+           If this starter here would default to localhost as well, a driver bean would always be
+           provided and SDN/OGM would back off even when a user configured a different URI.
+
 This is the bare minimum of what you need to connect to a Neo4j instance.
 
 Refer to <<Configuration options,the list of configuration properties>> for all options this driver supports.

--- a/neo4j-java-driver-spring-boot-autoconfigure/src/main/java/org/neo4j/driver/springframework/boot/autoconfigure/Neo4jDriverProperties.java
+++ b/neo4j-java-driver-spring-boot-autoconfigure/src/main/java/org/neo4j/driver/springframework/boot/autoconfigure/Neo4jDriverProperties.java
@@ -44,7 +44,7 @@ public class Neo4jDriverProperties {
 	/**
 	 * The uri this driver should connect to. The driver supports bolt or neo4j as schemes.
 	 */
-	private URI uri = URI.create("bolt://localhost:7687");
+	private URI uri;
 
 	/**
 	 * The authentication the driver is supposed to use. Maybe null.

--- a/neo4j-java-driver-spring-boot-autoconfigure/src/test/java/org/neo4j/driver/springframework/boot/autoconfigure/Neo4jDriverPropertiesTest.java
+++ b/neo4j-java-driver-spring-boot-autoconfigure/src/test/java/org/neo4j/driver/springframework/boot/autoconfigure/Neo4jDriverPropertiesTest.java
@@ -356,7 +356,7 @@ class Neo4jDriverPropertiesTest {
 
 		@Test
 		@DisplayName("…should fail on custom certificates without cert file")
-		void trustCustomCertificatesShouldWork2() throws IOException {
+		void trustCustomCertificatesShouldWork2() {
 
 			TrustSettings settings = new TrustSettings();
 			settings.setStrategy(Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES);
@@ -366,6 +366,14 @@ class Neo4jDriverPropertiesTest {
 				.withMessage(
 					"Property org.neo4j.driver.config.trust-settings with value 'TRUST_CUSTOM_CA_SIGNED_CERTIFICATES' is invalid: Configured trust strategy requires a certificate file.");
 		}
+	}
+
+	@Test
+	@DisplayName("Should not assume default value for the URL")
+	void shouldNotAssumeDefaultValuesForUrl() {
+
+		Neo4jDriverProperties driverProperties = new Neo4jDriverProperties();
+		assertThat(driverProperties.getUri()).isNull();
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
This fixes #20. 