### PR TITLE
Fix the cross reference link

### DIFF
--- a/docs/manual/getting-started.adoc
+++ b/docs/manual/getting-started.adoc
@@ -129,7 +129,7 @@ IMPORTANT: The URI is required. Autoconfiguration will not be triggered without 
 
 This is the bare minimum of what you need to connect to a Neo4j instance.
 
-Refer to <<Configuration options,the list of configuration properties>> for all options this driver supports.
+Refer to https://github.com/neo4j/neo4j-java-driver-spring-boot-starter/blob/master/docs/appendix/configuration-options.adoc[the list of configuration properties] for all options this driver supports.
 
 While the above configuration is presented in the easiest format (an `application.properties` file),
 you are of course free to use any other declarative way to define properties in Spring Boot.


### PR DESCRIPTION
I'm using an absolute link because this page is included in https://github.com/neo4j-documentation/developer-guides/blob/publish/modules/ROOT/pages/java-driver-spring-boot-starter.adoc and published by Antora at https://neo4j.com/developer/java-driver-spring-boot-starter/